### PR TITLE
fix: Report minor typo

### DIFF
--- a/documentation/Windows NT Registry File (REGF) format.asciidoc
+++ b/documentation/Windows NT Registry File (REGF) format.asciidoc
@@ -354,7 +354,7 @@ The named key - version 1.1 is variable of size and consists of:
 | 4 | 2 | "nk" | Signature
 | 6 | 2 | | Flags +
 See section: <<named_key_flags,Flags>>
-| 10 | 8 | | Last (key) written date and time +
+| 8 | 8 | | Last (key) written date and time +
 Contains a FILETIME
 | 16 | 4 | | [yellow-background]*Unknown (Empty value)* +
 | 20 | 4 | | Parent key offset +


### PR DESCRIPTION
Fixes #18

Corrects an incorrect byte offset in the named key v1.1 structure table within `documentation/Windows NT Registry File (REGF) format.asciidoc`. The "Last (key) written date and time" field was documented at offset 10, but the correct offset is 8, as the preceding fields (signature at offset 4, size 2; flags at offset 6, size 2) only span bytes 4-7. Updates the offset value from `10` to `8` in the AsciiDoc table. Verified by cross-checking the field layout against adjacent offsets (16 for Unknown, 20 for Parent key offset) which remain consistent with the corrected value.